### PR TITLE
SDK-1133: Retrieve the same attribute with different constraints

### DIFF
--- a/lib/yoti/data_type/base_profile.rb
+++ b/lib/yoti/data_type/base_profile.rb
@@ -15,6 +15,17 @@ module Yoti
     end
 
     #
+    # Returns the full list of all attributes
+    #
+    # @return [Array<Yoti::Attribute>>]
+    #
+    def attribute_list
+      @attributes.map do |_, value|
+        [value]
+      end.flatten
+    end
+
+    #
     # @param [Hash{String => Yoti::Attribute},Array<Yoti::Attribute>] profile_data
     #
     def initialize(profile_data)

--- a/lib/yoti/data_type/base_profile.rb
+++ b/lib/yoti/data_type/base_profile.rb
@@ -4,17 +4,32 @@ module Yoti
   #
   class BaseProfile
     #
-    # Return all attributes for the profile.
+    # Return the first attribute for each attribute in the profile.
     #
     # @return [Hash{String => Yoti::Attribute}]
     #
-    attr_reader :attributes
+    def attributes
+      @attributes.map do |key, values|
+        [key, values[0]]
+      end.to_h
+    end
 
     #
-    # @param [Hash{String => Yoti::Attribute}] profile_data
+    # @param [Hash{String => Yoti::Attribute},Array<Yoti::Attribute>] profile_data
     #
     def initialize(profile_data)
-      @attributes = profile_data.is_a?(Object) ? profile_data : {}
+      @attributes = {}
+
+      if profile_data.is_a? Hash
+        @attributes = profile_data.map do |key, value|
+          [key, [value]]
+        end.to_h
+      elsif profile_data.is_a? Array
+        profile_data.reject(&:nil?).each do |attr|
+          @attributes[attr.name] = [] unless @attributes[attr.name]
+          @attributes[attr.name].push attr
+        end
+      end
     end
 
     #
@@ -27,7 +42,20 @@ module Yoti
     def get_attribute(attr_name)
       return nil unless @attributes.key? attr_name
 
-      @attributes[attr_name]
+      @attributes[attr_name][0]
+    end
+
+    #
+    # Get all attributes with the given attribute name
+    #
+    # @param [String] name The name of the attribute
+    #
+    # @return [Array<Attribute>]
+    #
+    def get_all_attributes_by_name(name)
+      return [] unless @attributes.key? name
+
+      @attributes[name]
     end
 
     protected
@@ -37,10 +65,12 @@ module Yoti
     #
     # @param [String] name
     #
-    # @returns [Array]
+    # @returns [Hash]
     #
     def find_attributes_starting_with(name)
-      @attributes.select { |key| key.to_s.start_with?(name) }
+      @attributes.select { |key| key.to_s.start_with?(name) }.map do |key, values|
+        [key, values[0]]
+      end.to_h
     end
   end
 end

--- a/spec/yoti/data_type/profile_spec.rb
+++ b/spec/yoti/data_type/profile_spec.rb
@@ -187,33 +187,42 @@ describe 'Yoti::Profile' do
     end
   end
 
-  describe '.get_all_attributes_by_name' do
-    context 'with multiple attributes of the same name' do
-      let :multiname_profile do
-        Yoti::Profile.new([
-                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 1', {}, {}),
-                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 2', {}, {}),
-                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 3', {}, {})
-                          ])
-      end
+  context 'with multiple attributes of the same name' do
+    let :multiname_profile do
+      Yoti::Profile.new([
+                          Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 1', {}, {}),
+                          Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 2', {}, {}),
+                          Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 3', {}, {})
+                        ])
+    end
 
+    describe '.get_all_attributes_by_name' do
       it 'returns all the names' do
         expect(
           multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)
-            .length
+          .length
         ).to eql 3
         expect(
           multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[0]
-            .value
+          .value
         ).to eql 'Name 1'
         expect(
           multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[1]
-            .value
+          .value
         ).to eql 'Name 2'
         expect(
           multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[2]
-            .value
+          .value
         ).to eql 'Name 3'
+      end
+    end
+
+    describe '.attribute_list' do
+      it 'returns all the attributes' do
+        expect(multiname_profile.attribute_list.length).to eql 3
+        expect(multiname_profile.attribute_list[0].value).to eql 'Name 1'
+        expect(multiname_profile.attribute_list[1].value).to eql 'Name 2'
+        expect(multiname_profile.attribute_list[2].value).to eql 'Name 3'
       end
     end
   end

--- a/spec/yoti/data_type/profile_spec.rb
+++ b/spec/yoti/data_type/profile_spec.rb
@@ -186,4 +186,35 @@ describe 'Yoti::Profile' do
       expect(verification).to be_nil
     end
   end
+
+  describe '.get_all_attributes_by_name' do
+    context 'with multiple attributes of the same name' do
+      let :multiname_profile do
+        Yoti::Profile.new([
+                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 1', {}, {}),
+                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 2', {}, {}),
+                            Yoti::Attribute.new(Yoti::Attribute::FULL_NAME, 'Name 3', {}, {})
+                          ])
+      end
+
+      it 'returns all the names' do
+        expect(
+          multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)
+            .length
+        ).to eql 3
+        expect(
+          multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[0]
+            .value
+        ).to eql 'Name 1'
+        expect(
+          multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[1]
+            .value
+        ).to eql 'Name 2'
+        expect(
+          multiname_profile.get_all_attributes_by_name(Yoti::Attribute::FULL_NAME)[2]
+            .value
+        ).to eql 'Name 3'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add get_all_attributes_by_name(string):array to return a list of
attributes sharing the same attribute name.

### TODO
 * [ ] Test on Live